### PR TITLE
Record how many time GVL was released

### DIFF
--- a/lib/gvl_timing.rb
+++ b/lib/gvl_timing.rb
@@ -43,11 +43,12 @@ module GVLTiming
 
 
     def inspect
-      "#<#{self.class} total=%.2fs running=%.2fs idle=%.2fs stalled=%.2fs>" % [
+      "#<#{self.class} total=%.2fs running=%.2fs idle=%.2fs stalled=%.2fs, releases=%d>" % [
         duration,
         running_duration,
         idle_duration,
         stalled_duration,
+        releases_count,
       ]
     end
 

--- a/test/test_gvl_timing.rb
+++ b/test/test_gvl_timing.rb
@@ -18,6 +18,7 @@ class TestGVLTiming < Minitest::Test
     assert_in_delta 0, timer.cpu_duration_ns, 5000000
     assert_in_delta 0, timer.stalled_duration_ns, 5000000
     assert_in_delta 0, timer.running_duration_ns, 5000000
+    assert_operator 0, :<, timer.releases_count
   end
 
   def test_timing_busy_sleep
@@ -83,7 +84,7 @@ class TestGVLTiming < Minitest::Test
 
   def test_measure_and_inspect
     timer = GVLTiming.measure { sleep 0.1 }
-    expected = "#<GVLTiming::Timer total=0.10s running=0.00s idle=0.10s stalled=0.00s>"
+    expected = "#<GVLTiming::Timer total=0.10s running=0.00s idle=0.10s stalled=0.00s, releases=1>"
     assert_equal expected, timer.inspect
   end
 end


### PR DESCRIPTION
I used `gvl_timing` to instrument lobste.rs: https://github.com/lobsters/lobsters/pull/1442

One piece of data I wish was included was how many time the GVL was released by the thread. Because when you see a high stall time, you can't really tell if it was due to very high contention, or to moderate contention but the thread had to acquire the GVL many times.

More context: https://gist.github.com/byroot/e05508397ed1752e3521fa5c5a2da984

cc @jhawthorn 