### PR TITLE
Fix leak of timer when exception is raised

### DIFF
--- a/lib/gvl_timing.rb
+++ b/lib/gvl_timing.rb
@@ -10,8 +10,11 @@ module GVLTiming
     def measure
       timer = Timer.new
       timer.start
-      yield
-      timer.stop
+      begin
+        yield
+      ensure
+        timer.stop
+      end
       timer
     end
     alias_method :time, :measure


### PR DESCRIPTION
We're using the [gvl_metrics_middleware](https://github.com/speedshop/gvl_metrics_middleware/) gem to record GVL wait in our Sidekiq workloads. We noticed that during times of high exceptions, processing of Sidekiq slows down considerably over time. We tracked this down to a leak of this `Timer`'s thread callback when an exception is raised inside the `measure` block. Each call to `Timer#start` adds an event hook using `rb_internal_thread_add_event_hook` and since that hook is not removed in the case of an exception preventing `stop` from being called, the callback hooks accumulate over time until they have a large performance impact on the Ruby VM. 

We propose a change so that even if an exception occurs during the `measure` block, the timer is stopped. This prevents the leak of thread event callbacks. 

<details>

<summary>A script that illustrates the overhead added over time by exceptions being raised. </summary>

``` ruby
require 'bundler/inline'
require 'logger'
require 'tempfile'

gemfile do
  source 'https://rubygems.org'
  gem 'gvl_timing', path: '../gvl_timing'
end

Thread.new do
  last_time = Time.now.to_f
  i = 0
  while true do
    if i % 1000 == 0 then
      n = Time.now.to_f
      puts "time to do %dk %f" % [i/1000, String(n - last_time)]
      last_time = n
    end
    i += 1
    sleep 0.001
  end
end

Logger.new(Tempfile.new)
while true do
  begin
    sleep 0.001
    GVLTiming.measure { raise }
  rescue
  end
end
```

## Output prior to this change
The time it takes to sleep gradually goes up as each exception is encountered
```
❯ ruby exception_benchmark.rb
time to do 0k 0.000013
time to do 1k 1.313196
time to do 2k 1.396410
time to do 3k 1.510310
time to do 4k 1.748455
time to do 5k 1.877307
time to do 6k 1.926745
...
time to do 44k 3.726701
time to do 45k 4.176819
time to do 46k 4.198562
time to do 47k 4.006820
time to do 48k 4.198058
time to do 49k 4.056478
time to do 50k 4.144706
time to do 51k 4.333428
time to do 52k 4.221440
time to do 53k 4.380491
time to do 54k 4.490008
time to do 55k 4.366562
time to do 56k 4.441933
time to do 57k 4.542425
time to do 58k 4.601691
time to do 59k 4.606431
time to do 60k 4.649332
```




## Output after this change
The time is consistently ~1.2 seconds even as exceptions are raised in the `measure` block
```
❯ ruby exception_benchmark.rb
time to do 0k 0.000015
time to do 1k 1.280211
time to do 2k 1.294176
time to do 3k 1.254699
time to do 4k 1.277259
...
time to do 103k 1.278481
time to do 104k 1.284164
```