### PR TITLE
Expose methods for object state

### DIFF
--- a/ext/gvl_timing/gvl_timing.c
+++ b/ext/gvl_timing/gvl_timing.c
@@ -171,6 +171,27 @@ VALUE gvl_timer_idle_duration(VALUE obj) {
     return ULL2NUM(get_timer(obj)->timings[GVL_STATE_IDLE]);
 }
 
+VALUE gvl_timer_active(VALUE obj) {
+    return get_timer(obj)->running ? Qtrue : Qfalse;
+}
+
+VALUE gvl_timer_current_state(VALUE obj) {
+    switch (get_timer(obj)->prev_state) {
+      case GVL_STATE_RUNNING:
+        return ID2SYM(rb_intern("running"));
+      case GVL_STATE_STALLED:
+        return ID2SYM(rb_intern("stalled"));
+      case GVL_STATE_IDLE:
+        return ID2SYM(rb_intern("idle"));
+      default:
+        return Qnil;
+    }
+}
+
+VALUE gvl_timer_monotonic_state_changed_ns(VALUE obj) {
+    return ULL2NUM(get_timer(obj)->prev_timestamp);
+}
+
 VALUE gvl_timer_yields_count(VALUE obj) {
     return ULL2NUM(get_timer(obj)->yields_count);
 }
@@ -193,5 +214,8 @@ Init_gvl_timing(void)
     rb_define_method(rb_cTimer, "stalled_duration_ns", gvl_timer_stalled_duration, 0);
     rb_define_method(rb_cTimer, "idle_duration_ns", gvl_timer_idle_duration, 0);
 
+    rb_define_method(rb_cTimer, "active?", gvl_timer_active, 0);
+    rb_define_method(rb_cTimer, "current_state", gvl_timer_current_state, 0);
+    rb_define_method(rb_cTimer, "monotonic_state_changed_ns", gvl_timer_monotonic_state_changed_ns, 0);
     rb_define_method(rb_cTimer, "yields_count", gvl_timer_yields_count, 0);
 }

--- a/test/test_gvl_timing.rb
+++ b/test/test_gvl_timing.rb
@@ -87,4 +87,49 @@ class TestGVLTiming < Minitest::Test
     expected = "#<GVLTiming::Timer total=0.10s running=0.00s idle=0.10s stalled=0.00s yields=1>"
     assert_equal expected, timer.inspect
   end
+
+  def test_current_state
+    timer = GVLTiming::Timer.new
+    timer.start
+
+    idle_thread = Thread.new do
+      sleep 0.05
+      timer.current_state
+    end
+
+    sleep 0.1
+
+    state_while_sleeping = idle_thread.join.value
+
+    assert_equal :idle, state_while_sleeping
+    assert_equal :running, timer.current_state
+  ensure
+    timer.stop
+  end
+
+  def test_monotonic_state_changed_ns
+    timer = GVLTiming::Timer.new
+    timer.start
+
+    initial_state_changed = timer.monotonic_state_changed_ns
+
+    sleep 0.1
+
+    last_state_changed = timer.monotonic_state_changed_ns
+
+    assert_in_delta 100_000_000, (last_state_changed - initial_state_changed), 5_000_000
+  ensure
+    timer.stop
+  end
+
+  def test_running
+    timer = GVLTiming::Timer.new
+    timer.start
+
+    assert timer.active?, "timer not active"
+
+    timer.stop
+
+    assert !timer.active?, "timer still active"
+  end
 end


### PR DESCRIPTION
I wanted to use the data that is not exposed to the Ruby world in order to track metrics even from running timers (e.g. measure metrics for the target threads each second). The `running` flag, `prev_state` and `prev_timestamp` are useful when calculating a slice of each time window.