### PR TITLE
Introduces a new `GlobalTimer` class

### DIFF
--- a/ext/gvl_timing/gvl_timing.c
+++ b/ext/gvl_timing/gvl_timing.c
@@ -3,6 +3,9 @@
 
 static VALUE rb_mGVLTiming;
 static VALUE rb_cTimer;
+static VALUE rb_cGlobalTimer;
+
+static int thread_storage_key = 0;
 
 static const uint64_t nanoseconds_per_second = 1000000000;
 
@@ -33,8 +36,43 @@ struct gvl_timer {
     VALUE thread;
     rb_internal_thread_event_hook_t *event_hook;
 
+    bool global;
     bool running;
 };
+
+typedef struct {
+    VALUE thread;
+    uint64_t prev_timestamp;
+    enum ruby_gvl_state prev_state;
+} thread_local_state;
+
+static size_t thread_local_state_memsize(const void *data) {
+    return sizeof(thread_local_state);
+}
+
+static const rb_data_type_t thread_local_state_type = {
+    .wrap_struct_name = "GVLTiming::ThreadState",
+    .function = {
+        .dmark = NULL,
+        .dfree = RUBY_DEFAULT_FREE,
+        .dsize = thread_local_state_memsize,
+    },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY | RUBY_TYPED_WB_PROTECTED,
+};
+
+static inline thread_local_state *GT_LOCAL_STATE(VALUE thread, bool allocate) {
+    thread_local_state *state = rb_internal_thread_specific_get(thread, thread_storage_key);
+
+    if (!state && allocate) {
+        VALUE wrapper = TypedData_Make_Struct(rb_cGlobalTimer, thread_local_state, &thread_local_state_type, state);
+        rb_thread_local_aset(thread, rb_intern("__gvl_timing_thread_state"), wrapper);
+        RB_GC_GUARD(wrapper);
+        rb_internal_thread_specific_set(thread, thread_storage_key, state);
+    }
+    return state;
+}
+
+#define GT_EVENT_LOCAL_STATE(event_data, allocate) GT_LOCAL_STATE(event_data->thread, allocate)
 
 void record_timing(struct gvl_timer *timer, enum ruby_gvl_state new_state) {
     uint64_t timestamp = clock_gettime_ns(CLOCK_MONOTONIC);
@@ -48,6 +86,19 @@ void record_timing(struct gvl_timer *timer, enum ruby_gvl_state new_state) {
     }
 }
 
+void record_global_timing(struct gvl_timer *global_timer, enum ruby_gvl_state new_state, thread_local_state *thread_state) {
+    uint64_t timestamp = clock_gettime_ns(CLOCK_MONOTONIC);
+
+    global_timer->timings[thread_state->prev_state] += (timestamp - thread_state->prev_timestamp);
+
+    thread_state->prev_timestamp = timestamp;
+    thread_state->prev_state = new_state;
+
+    if (new_state == GVL_STATE_IDLE) {
+        global_timer->yields_count++;
+    }
+}
+
 void internal_thread_event_cb(rb_event_flag_t event, const rb_internal_thread_event_data_t *event_data, void *data) {
     struct gvl_timer *timer = data;
 
@@ -58,12 +109,24 @@ void internal_thread_event_cb(rb_event_flag_t event, const rb_internal_thread_ev
     if (!ruby_native_thread_p()) return;
     thread = rb_thread_current();
 #endif
-    if (thread != timer->thread) {
+    if (!timer->global && thread != timer->thread) {
         return;
     }
 
     enum ruby_gvl_state new_state;
     switch (event) {
+      case RUBY_INTERNAL_THREAD_EVENT_STARTED: {
+        if (timer->global) {
+//             The STARTED event is triggered from the parent thread with the GVL held
+//             so we can allocate the struct.
+            thread_local_state *thread_state = GT_EVENT_LOCAL_STATE(event_data, true);
+
+            thread_state->prev_timestamp = clock_gettime_ns(CLOCK_MONOTONIC);
+            thread_state->prev_state = GVL_STATE_RUNNING;
+        }
+        return;
+      }
+      break;
       case RUBY_INTERNAL_THREAD_EVENT_READY:
         new_state = GVL_STATE_STALLED;
         break;
@@ -77,7 +140,15 @@ void internal_thread_event_cb(rb_event_flag_t event, const rb_internal_thread_ev
         return;
     }
 
-    record_timing(timer, new_state);
+    if (timer->global) {
+        thread_local_state *prev_state = GT_EVENT_LOCAL_STATE(event_data, false);
+
+        if (prev_state) {
+            record_global_timing(timer, new_state, prev_state);
+        }
+    } else {
+        record_timing(timer, new_state);
+    }
 }
 
 static size_t gvl_timer_memsize(const void *data) {
@@ -120,6 +191,7 @@ VALUE gvl_timer_start(VALUE obj) {
     timer->cputime_start   = clock_gettime_ns(CLOCK_THREAD_CPUTIME_ID);
 
     timer->thread = rb_thread_current();
+    timer->global = false;
     timer->running = true;
     timer->event_hook = rb_internal_thread_add_event_hook(internal_thread_event_cb, RUBY_INTERNAL_THREAD_EVENT_MASK, timer);
 
@@ -129,10 +201,52 @@ VALUE gvl_timer_start(VALUE obj) {
     return obj;
 }
 
+VALUE gvl_global_timer_start(VALUE obj) {
+    struct gvl_timer *timer = get_timer(obj);
+    timer->monotonic_start = clock_gettime_ns(CLOCK_MONOTONIC);
+
+    timer->global = true;
+    timer->running = true;
+    timer->event_hook = rb_internal_thread_add_event_hook(internal_thread_event_cb, RUBY_INTERNAL_THREAD_EVENT_MASK, timer);
+
+    timer->prev_state = GVL_STATE_RUNNING;
+    timer->prev_timestamp = clock_gettime_ns(CLOCK_MONOTONIC);
+
+    thread_local_state *thread_state = GT_LOCAL_STATE(rb_thread_current(), true);
+
+    thread_state->prev_state = GVL_STATE_RUNNING;
+    thread_state->prev_timestamp = clock_gettime_ns(CLOCK_MONOTONIC);
+
+    return obj;
+}
+
 VALUE gvl_timer_stop(VALUE obj) {
     struct gvl_timer *timer = get_timer(obj);
 
     // Record last interval
+    record_timing(timer, GVL_STATE_RUNNING);
+
+    rb_internal_thread_remove_event_hook(timer->event_hook);
+
+    timer->monotonic_stop = clock_gettime_ns(CLOCK_MONOTONIC);
+    timer->cputime_stop   = clock_gettime_ns(CLOCK_THREAD_CPUTIME_ID);
+    timer->running = false;
+    return obj;
+}
+
+VALUE gvl_global_timer_reset(VALUE obj) {
+    struct gvl_timer *timer = get_timer(obj);
+
+    timer->timings[GVL_STATE_RUNNING] = 0;
+    timer->timings[GVL_STATE_STALLED] = 0;
+    timer->timings[GVL_STATE_IDLE] = 0;
+
+    return obj;
+}
+
+VALUE gvl_global_timer_stop(VALUE obj) {
+    struct gvl_timer *timer = get_timer(obj);
+
     record_timing(timer, GVL_STATE_RUNNING);
 
     rb_internal_thread_remove_event_hook(timer->event_hook);
@@ -178,6 +292,8 @@ VALUE gvl_timer_yields_count(VALUE obj) {
 RUBY_FUNC_EXPORTED void
 Init_gvl_timing(void)
 {
+    thread_storage_key = rb_internal_thread_specific_key_create();
+
     rb_mGVLTiming = rb_define_module("GVLTiming");
     rb_cTimer = rb_define_class_under(rb_mGVLTiming, "Timer", rb_cObject);
     rb_define_alloc_func(rb_cTimer, gvl_timer_alloc);
@@ -194,4 +310,21 @@ Init_gvl_timing(void)
     rb_define_method(rb_cTimer, "idle_duration_ns", gvl_timer_idle_duration, 0);
 
     rb_define_method(rb_cTimer, "yields_count", gvl_timer_yields_count, 0);
+
+    rb_cGlobalTimer = rb_define_class_under(rb_mGVLTiming, "GlobalTimer", rb_cObject);
+    rb_define_alloc_func(rb_cGlobalTimer, gvl_timer_alloc);
+    rb_define_method(rb_cGlobalTimer, "start", gvl_global_timer_start, 0);
+    rb_define_method(rb_cGlobalTimer, "reset", gvl_global_timer_reset, 0);
+    rb_define_method(rb_cGlobalTimer, "stop", gvl_global_timer_stop, 0);
+
+    rb_define_method(rb_cGlobalTimer, "monotonic_start_ns", gvl_timer_monotonic_start, 0);
+    rb_define_method(rb_cGlobalTimer, "monotonic_stop_ns", gvl_timer_monotonic_stop, 0);
+    rb_define_method(rb_cGlobalTimer, "cputime_start_ns", gvl_timer_cputime_start, 0);
+    rb_define_method(rb_cGlobalTimer, "cputime_stop_ns", gvl_timer_cputime_stop, 0);
+
+    rb_define_method(rb_cGlobalTimer, "running_duration_ns", gvl_timer_running_duration, 0);
+    rb_define_method(rb_cGlobalTimer, "stalled_duration_ns", gvl_timer_stalled_duration, 0);
+    rb_define_method(rb_cGlobalTimer, "idle_duration_ns", gvl_timer_idle_duration, 0);
+
+    rb_define_method(rb_cGlobalTimer, "yields_count", gvl_timer_yields_count, 0);
 }

--- a/lib/gvl_timing.rb
+++ b/lib/gvl_timing.rb
@@ -20,9 +20,7 @@ module GVLTiming
     alias_method :time, :measure
   end
 
-  class Timer
-    NANOSECONDS_PER_SECOND_F = 1000000000.0
-
+  module TimingCalculable
     def duration_ns
       monotonic_stop_ns - monotonic_start_ns
     end
@@ -43,8 +41,6 @@ module GVLTiming
         end
       RUBY
     end
-
-    alias releases_count yields_count
 
     def inspect
       "#<#{self.class} total=%.2fs running=%.2fs idle=%.2fs stalled=%.2fs yields=%d>" % [
@@ -78,5 +74,17 @@ module GVLTiming
         raise ArgumentError, "unexpected unit: #{unit.inspect}"
       end
     end
+  end
+
+  class Timer
+    include TimingCalculable
+
+    alias releases_count yields_count
+  end
+
+  class GlobalTimer
+    include TimingCalculable
+
+    alias releases_count yields_count
   end
 end

--- a/test/test_gvl_global_timing.rb
+++ b/test/test_gvl_global_timing.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TestGVLGlobalTiming < Minitest::Test
+  def test_timing_idle_sleep
+    timer = GVLTiming::GlobalTimer.new
+    timer.start
+    Thread.new { sleep 0.1 }.join
+    timer.stop
+
+    assert_in_delta 100_000_000, timer.duration_ns, 6_000_000
+    assert_in_delta 100_000_000, timer.running_duration_ns, 6_000_000
+    assert_in_delta 0, timer.stalled_duration_ns, 1_000_000
+    assert_in_delta 200_000_000, timer.idle_duration_ns, 6_000_000
+    assert_equal 2, timer.releases_count
+  end
+
+  private
+
+  def test_timing_busy_sleep
+    timer = GVLTiming::GlobalTimer.new
+    timer.start
+
+    Thread.new {
+      target = Process::clock_gettime(Process::CLOCK_MONOTONIC) + 0.1
+
+      while Process::clock_gettime(Process::CLOCK_MONOTONIC) < target
+        # busy
+      end
+    }.join
+
+    timer.stop
+
+    assert_in_delta 100000000, timer.duration_ns, 5000000
+    assert_in_delta 100000000, timer.running_duration_ns, 5000000
+    assert_in_delta 0, timer.stalled_duration_ns, 5000000
+    assert_in_delta 100000000, timer.idle_duration_ns, 5000000
+  end
+
+  def test_timing_stalled_sleep
+    done = false
+    wait = Mutex.new
+    wait.lock
+    thread = Thread.new do
+      wait.lock
+      target = Process::clock_gettime(Process::CLOCK_MONOTONIC) + 0.1
+      while Process::clock_gettime(Process::CLOCK_MONOTONIC) < target
+        # busy
+      end
+      done = true
+    end
+
+
+    timer = GVLTiming::GlobalTimer.new
+    timer.start
+
+    Thread.new { sleep 0.1 }
+
+    wait.unlock
+    Thread.pass
+    until done
+      Thread.pass
+    end
+    timer.stop
+
+    assert_in_delta 100000000, timer.duration_ns, 5000000
+    assert_in_delta 100000000, timer.running_duration_ns, 5000000
+    assert_in_delta 100000000, timer.stalled_duration_ns, 5000000
+    assert_in_delta 0, timer.idle_duration_ns, 5000000
+  ensure
+    thread&.kill
+  end
+
+  # def test_timing_units
+  #   timer = GVLTiming.measure { sleep 0.1 }
+  #
+  #   assert_in_delta 100000000, timer.duration_ns, 5000000
+  #   assert_in_delta 0.1, timer.duration, 0.005
+  #   assert_in_delta 0.1, timer.duration(:float_second), 0.005
+  #   assert_in_delta 100, timer.duration(:float_millisecond), 5
+  #   assert_in_delta 100_000, timer.duration(:float_microsecond), 5000
+  #
+  #   assert_equal 0, timer.duration(:second)
+  #   assert_in_delta 100, timer.duration(:millisecond), 5
+  #   assert_in_delta 100_000, timer.duration(:microsecond), 5_000
+  #   assert_in_delta 100_000_000, timer.duration(:nanosecond), 5_000_000
+  # end
+  #
+  # def test_measure_and_inspect
+  #   timer = GVLTiming.measure { sleep 0.1 }
+  #   expected = "#<GVLTiming::Timer total=0.10s running=0.00s idle=0.10s stalled=0.00s yields=1>"
+  #   assert_equal expected, timer.inspect
+  # end
+
+  private
+
+  def fib(n)
+    return n if n < 2
+    fib(n - 1) + fib(n - 2)
+  end
+end

--- a/test/test_gvl_local_timing.rb
+++ b/test/test_gvl_local_timing.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class TestGVLTiming < Minitest::Test
+class TestGVLLocalTiming < Minitest::Test
   def test_that_it_has_a_version_number
     refute_nil ::GVLTiming::VERSION
   end


### PR DESCRIPTION
Addresses #2. This is still WIP and needs a bit more testing cleanup. I ended up not using this entire code I would like this to be just a ferecence for other future work (hence the dract PR). I may continue to work on this depending on the demand.

This pull request introduces a new `GlobalTimer` class to the `gvl_timing` extension, enabling global GVL (Global VM Lock) timing across all threads, alongside internal refactoring to support per-thread state and event-driven timing. It also adds comprehensive tests for the new functionality and refines the Ruby interface for both timer types.

**Global GVL timing support:**

- Added a new `GVLTiming::GlobalTimer` class in C and Ruby, which tracks GVL timing across all threads using per-thread state and event hooks. This includes new C functions and Ruby methods for starting, stopping, and resetting the global timer, as well as reporting durations for running, stalled, and idle states. [[1]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR6-R8) [[2]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR39-R76) [[3]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR89-R101) [[4]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aL61-R129) [[5]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR143-R152) [[6]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR194) [[7]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR204-R222) [[8]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR237-R259) [[9]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR295-R296) [[10]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR313-R329) [[11]](diffhunk://#diff-c86b35f0c5efdcd0253c0725495c16eac7d5c57fdd2df70d2d2806684edfe4fbL23-R23) [[12]](diffhunk://#diff-c86b35f0c5efdcd0253c0725495c16eac7d5c57fdd2df70d2d2806684edfe4fbL47-L48) [[13]](diffhunk://#diff-c86b35f0c5efdcd0253c0725495c16eac7d5c57fdd2df70d2d2806684edfe4fbR78-R89)

**Internal refactoring and enhancements:**

- Introduced per-thread local state with a new `thread_local_state` struct and related management functions/macros to accurately record timing events for each thread in global mode. [[1]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR39-R76) [[2]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aL61-R129) [[3]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR143-R152)
- Refactored event callback logic to distinguish between local and global timers, ensuring correct handling for both timer types. [[1]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aL61-R129) [[2]](diffhunk://#diff-890c65fb037b6a3c2ae7679e065735b6206078bfcc3e41463ed0a21591e5977aR143-R152)

**Testing:**

- Added a new test suite in `test/test_gvl_global_timing.rb` with multiple scenarios to validate the accuracy of `GlobalTimer` under various thread behaviors (idle, busy, stalled).
- Renamed the original test file to `test/test_gvl_local_timing.rb` and updated the test class name for clarity.

**Ruby interface changes:**

- Extracted shared duration calculation logic into a `TimingCalculable` module, included by both `Timer` and `GlobalTimer` Ruby classes to reduce duplication and improve maintainability. [[1]](diffhunk://#diff-c86b35f0c5efdcd0253c0725495c16eac7d5c57fdd2df70d2d2806684edfe4fbL23-R23) [[2]](diffhunk://#diff-c86b35f0c5efdcd0253c0725495c16eac7d5c57fdd2df70d2d2806684edfe4fbR78-R89)
- Ensured both timer classes have consistent method aliases and inspection output. [[1]](diffhunk://#diff-c86b35f0c5efdcd0253c0725495c16eac7d5c57fdd2df70d2d2806684edfe4fbL47-L48) [[2]](diffhunk://#diff-c86b35f0c5efdcd0253c0725495c16eac7d5c57fdd2df70d2d2806684edfe4fbR78-R89)